### PR TITLE
websocket example opens connection on startup

### DIFF
--- a/examples/websocket/src/main/scala/indigoexamples/WebSocketExample.scala
+++ b/examples/websocket/src/main/scala/indigoexamples/WebSocketExample.scala
@@ -44,7 +44,7 @@ object WebSocketExample extends IndigoDemo[Unit, WebSocketConfig, Batch[String],
         bounds = Rectangle(100, 10, 16, 16),
         depth = Depth(2)
       ).withUpActions(WebSocketEvent.Send("Hello!", echoSocket))
-    )
+    ).addGlobalEvents(WebSocketEvent.Open("Opening connection", echoSocket))
 
   def updateModel(context: FrameContext[WebSocketConfig], log: Batch[String]): GlobalEvent => Outcome[Batch[String]] = {
     case WebSocketEvent.Receive(WebSocketId("echo"), message) =>


### PR DESCRIPTION
Previously the websocket example would ignore the first player input when pressing the button. With this change the game engine will open a websocket connection on startup so the first input will not be ignored.